### PR TITLE
Deprecate jenkins by removing Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,0 @@
-#!/usr/bin/env groovy
-common {
-  slackChannel = '#data-governance-eng'
-  nanoVersion = true
-  disableConcurrentBuilds = true
-}


### PR DESCRIPTION
Semaphore was able to build master branch successfully and release process succeeded. This PR finishes Semaphore migration by removing Jenkins